### PR TITLE
Null propagation checking

### DIFF
--- a/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
+++ b/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
@@ -44,7 +44,7 @@ namespace WebApi.Jwt.Filters
             username = null;
 
             var simplePrinciple = JwtManager.GetPrincipal(token);
-            var identity = simplePrinciple.Identity as ClaimsIdentity;
+            var identity = simplePrinciple?.Identity as ClaimsIdentity;
 
             if (identity == null)
                 return false;


### PR DESCRIPTION
Propagated null value when  JwtManager.GetPrincipal(token) doesn't return a simplePrinciple because ex. submitted token is not valid. 
With a token that is not valid JwtManager.GetPrincipal inside throw the follow System.ArgumentException: "IDX10723: Unable to decode the payload 'eyJ1bmlxdWVfbmFtZSI6ImN1b25nIiwibmJmIjoxNTEzdNjI2MzA4LCJleHAiOjE1MTM2Mjc1MDgsImlhdCI6MTUxMzYyNjMwOH0' as Base64Url encoded string. jwtEncodedString: '"