### PR TITLE
 Missing bearer token would result in Authorized

### DIFF
--- a/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
+++ b/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
@@ -18,11 +18,11 @@ namespace WebApi.Jwt.Filters
             var request = context.Request;
             var authorization = request.Headers.Authorization;
 
-			if (authorization == null || string.IsNullOrEmpty(authorization.Parameter) || !authorization.Scheme.Equals("bearer", StringComparison.OrdinalIgnoreCase))
-			{
-				context.ErrorResult = new AuthenticationFailureResult("Missing Jwt Token", request);
-				return;
-			}
+	    if (authorization == null || string.IsNullOrEmpty(authorization.Parameter) || !authorization.Scheme.Equals("bearer", StringComparison.OrdinalIgnoreCase))
+	    {
+		context.ErrorResult = new AuthenticationFailureResult("Missing Jwt Token", request);
+		return;
+	    }
 
             var token = authorization.Parameter;
             var principal = await AuthenticateJwtToken(token);

--- a/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
+++ b/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
@@ -18,27 +18,20 @@ namespace WebApi.Jwt.Filters
             var request = context.Request;
             var authorization = request.Headers.Authorization;
 
-            if (authorization == null || authorization.Scheme != "Bearer")
-                return;
-
-            if (string.IsNullOrEmpty(authorization.Parameter))
-            {
-                context.ErrorResult = new AuthenticationFailureResult("Missing Jwt Token", request);
-                return;
-            }
+			if (authorization == null || string.IsNullOrEmpty(authorization.Parameter) || !authorization.Scheme.Equals("bearer", StringComparison.OrdinalIgnoreCase))
+			{
+				context.ErrorResult = new AuthenticationFailureResult("Missing Jwt Token", request);
+				return;
+			}
 
             var token = authorization.Parameter;
             var principal = await AuthenticateJwtToken(token);
 
             if (principal == null)
                 context.ErrorResult = new AuthenticationFailureResult("Invalid token", request);
-
             else
                 context.Principal = principal;
         }
-
-
-
         private static bool ValidateToken(string token, out string username)
         {
             username = null;


### PR DESCRIPTION
If you didn't supply a bearer token, the action would be authorized. Should always result in a Unauthorized, if not all requirements were met.