### PR TITLE
Fix bug on missing Authorization header

### DIFF
--- a/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
+++ b/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
@@ -19,7 +19,10 @@ namespace WebApi.Jwt.Filters
             var authorization = request.Headers.Authorization;
 
             if (authorization == null || authorization.Scheme != "Bearer")
+            {
+                context.ErrorResult = new AuthenticationFailureResult("Missing Authorization Header", request);
                 return;
+            }
 
             if (string.IsNullOrEmpty(authorization.Parameter))
             {


### PR DESCRIPTION
I noticed that when the Authorization header is missing (line 21) no error is returned, hence the filter passes and the decorated API (with [JwtAuthentication]) is executed normally.
Adding context.ErrorResult assignment should fix the problem.
Since I'm not an expert in this field I apologise if my proposition is wrong, and I'd like to learn about what I've done wrong.