### PR TITLE
Authorization Missing Bug Fix

### DIFF
--- a/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
+++ b/WebApi.Jwt/Filters/JwtAuthenticationAttribute.cs
@@ -18,8 +18,10 @@ namespace WebApi.Jwt.Filters
             var request = context.Request;
             var authorization = request.Headers.Authorization;
 
-            if (authorization == null || authorization.Scheme != "Bearer")
+            if (authorization == null || authorization.Scheme != "Bearer") {
+                context.ErrorResult = new AuthenticationFailureResult("Missing Authorization",request);
                 return;
+            }
 
             if (string.IsNullOrEmpty(authorization.Parameter))
             {


### PR DESCRIPTION
If the **authorization** token is not provided or is **null**, then it **should not** execute the **API controller** code and show a response **401**.

> Previously even though the authorization is null, the API code was getting executed.